### PR TITLE
Optimize Location Filtering

### DIFF
--- a/ios/display-locations/observable/Filters.swift
+++ b/ios/display-locations/observable/Filters.swift
@@ -45,11 +45,10 @@ class Filters: ObservableObject {
     func calculateVisibleLocations() {
         visibleLocations = filters.keys.filter({ key in
             return filters[key] ?? false
-        }).reduce([Location]()) { soFar, type in
+        }).reduce(into: [Location]()) { accumlator, type in
             if let locationsMatchingType = locationsByType[type] {
-                return soFar + locationsMatchingType
+                accumlator.append(contentsOf: locationsMatchingType)
             }
-            return soFar
         }
     }
 }

--- a/ios/display-locations/observable/Filters.swift
+++ b/ios/display-locations/observable/Filters.swift
@@ -17,9 +17,11 @@ class Filters: ObservableObject {
     }
     @Published var locations = [Location]() {
         didSet {
+            categorizeLocations()
             calculateVisibleLocations()
         }
     }
+    private var locationsByType = Dictionary<LocationType, [Location]>()
     @Published var visibleLocations = [Location]()
 
     init() {
@@ -36,12 +38,18 @@ class Filters: ObservableObject {
         })
     }
 
+    func categorizeLocations() {
+        locationsByType = Dictionary.init(grouping: locations, by: { $0.type })
+    }
+
     func calculateVisibleLocations() {
-        let visibleTypes = filters.keys.filter({ key in
+        visibleLocations = filters.keys.filter({ key in
             return filters[key] ?? false
-        })
-        visibleLocations = locations.filter({ location in
-            return visibleTypes.contains(location.type)
-        })
+        }).reduce([Location]()) { soFar, type in
+            if let locationsMatchingType = locationsByType[type] {
+                return soFar + locationsMatchingType
+            }
+            return soFar
+        }
     }
 }

--- a/ios/display-locations/observable/Filters.swift
+++ b/ios/display-locations/observable/Filters.swift
@@ -38,11 +38,11 @@ class Filters: ObservableObject {
         })
     }
 
-    func categorizeLocations() {
+    private func categorizeLocations() {
         locationsByType = Dictionary.init(grouping: locations, by: { $0.type })
     }
 
-    func calculateVisibleLocations() {
+    private func calculateVisibleLocations() {
         visibleLocations = filters.keys.filter({ key in
             return filters[key] ?? false
         }).reduce(into: [Location]()) { accumlator, type in


### PR DESCRIPTION
We only fetch locations once. Thus when we fetch them we can immediately categorize them by type into a dictionary, keyed by type. When the active filters change, all we need to do is lookup the categories by the active filters, then append the arrays together.

We will append, rather than catenate, as under certain benchmarks, append is [20 times faster](https://www.mattrajca.com/2016/10/22/benchmarking-swift-array-append-vs-concatentation.html).